### PR TITLE
Fix output check in returnData

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,10 +45,10 @@ function returnData($data, $output=1) {
 		//saving generated xml file; 
 		// $result = $xml_data->asXML('/file/path/name.xml');
 		echo $xml_data->asXML();
-	} elseif($output==2) {
-		if(count($output)>0) echo $data[0];
-			else echo "";
-	}
+        } elseif($output==2) {
+                if(count($data)>0) echo $data[0];
+                        else echo "";
+        }
 }
 
 function getStrKey($arKeys) {


### PR DESCRIPTION
## Summary
- fix wrong variable reference when returning first element of array

## Testing
- `php -l index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68418b55523483338a989fc050bde9cd